### PR TITLE
Upgrading IntelliJ from 2022.2.4 to 2022.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2022.2.4 to 2022.3.0
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup = com.chriscarini.jetbrains
 pluginName = 'Automatic Power Saver'
 # SemVer format -> https://semver.org
-pluginVersion = 2.7.1
+pluginVersion = 2.8.0
 
 ### I DO NOT MAKE USE OF SINCE/UNTIL IN THIS PLUGIN.
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
@@ -14,7 +14,7 @@ pluginVersion = 2.7.1
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2022.2.4,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2022.3,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 # Exclude `DEPRECATED_API_USAGES` as we use `FrameStateListener.onFrameDeactivated()` in
 # `FocusPowerSaveService.IdeFrameStatePowerSaveListener` (2022.3)
@@ -28,7 +28,7 @@ platformType = IC
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2022.2.4
+platformVersion = 2022.3
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html

--- a/src/main/java/com/chriscarini/jetbrains/autopowersaver/FocusPowerSaveService.java
+++ b/src/main/java/com/chriscarini/jetbrains/autopowersaver/FocusPowerSaveService.java
@@ -5,13 +5,14 @@ import com.chriscarini.jetbrains.autopowersaver.settings.SettingsManager;
 import com.intellij.application.Topics;
 import com.intellij.concurrency.JobScheduler;
 import com.intellij.featureStatistics.FeatureUsageTracker;
-import com.intellij.ide.FrameStateListener;
 import com.intellij.ide.PowerSaveMode;
 import com.intellij.openapi.Disposable;
+import com.intellij.openapi.application.ApplicationActivationListener;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.Disposer;
+import com.intellij.openapi.wm.IdeFrame;
 import org.jetbrains.annotations.NonNls;
 
 import java.util.concurrent.ScheduledFuture;
@@ -28,7 +29,7 @@ public class FocusPowerSaveService implements Disposable {
   public FocusPowerSaveService() {
     Disposer.register(ApplicationManager.getApplication(), this);
 
-    Topics.subscribe(FrameStateListener.TOPIC, ApplicationManager.getApplication(),
+    Topics.subscribe(ApplicationActivationListener.TOPIC, ApplicationManager.getApplication(),
         new IdeFrameStatePowerSaveListener());
   }
 
@@ -52,9 +53,9 @@ public class FocusPowerSaveService implements Disposable {
   /**
    * Listener that enables/disables {@link PowerSaveMode} on frame activate/deactivate.
    */
-  private static class IdeFrameStatePowerSaveListener implements FrameStateListener {
+  private static class IdeFrameStatePowerSaveListener implements ApplicationActivationListener {
     @Override
-    public void onFrameActivated() {
+    public void applicationActivated(IdeFrame ideFrame) {
       LOG.debug("IDE Frame Activated...");
       if (ApplicationManager.getApplication().isDisposed()) {
         return;
@@ -86,7 +87,7 @@ public class FocusPowerSaveService implements Disposable {
     }
 
     @Override
-    public void onFrameDeactivated() {
+    public void applicationDeactivated(IdeFrame ideFrame) {
       LOG.debug("IDE Frame Deactivated...");
       if (ApplicationManager.getApplication().isDisposed()) {
         return;


### PR DESCRIPTION

# Upgrading IntelliJ from 2022.2.4 to 2022.3.0

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100661406/IntelliJ-IDEA-2022.3-223.7571.182-build-Release-Notes

# What's New?
IntelliJ IDEA 2022.3 is now available with the following updates: 
<ul> 
 <li>New IDE UI available via settings</li> 
 <li>New Settings Sync solution</li> 
 <li>New way to work with projects in WSL2</li> 
 <li>New actions for autowiring Spring beans and generating OpenAPI schemas</li> 
 <li>Redis support</li> 
</ul> Visit our 
<a href="https://www.jetbrains.com/idea/whatsnew/">What's New page</a> to learn about all of the new features and improvements.
    