### PR TITLE
Upgrading IntelliJ from 2022.3.3 to 2023.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2022.3.3 to 2023.1.0
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup = com.chriscarini.jetbrains
 pluginName = 'Automatic Power Saver'
 # SemVer format -> https://semver.org
-pluginVersion = 2.8.3
+pluginVersion = 3.0.0
 
 ### I DO NOT MAKE USE OF SINCE/UNTIL IN THIS PLUGIN.
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
@@ -14,7 +14,7 @@ pluginVersion = 2.8.3
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2022.3.3,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2023.1,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 # Exclude `DEPRECATED_API_USAGES` as we use `FrameStateListener.onFrameDeactivated()` in
 # `FocusPowerSaveService.IdeFrameStatePowerSaveListener` (2022.3)
@@ -28,7 +28,7 @@ platformType = IC
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2022.3.3
+platformVersion = 2023.1
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html


### PR DESCRIPTION

# Upgrading IntelliJ from 2022.3.3 to 2023.1.0

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100661478/IntelliJ-IDEA-2023.1-231.8109.175-build-Release-Notes

# What's New?
IntelliJ IDEA 2023.1 is now available with the following updates: 
<ul> 
 <li>New UI enhancements</li> 
 <li>Earlier availability of IDE features on project opening</li> 
 <li>Faster import of Maven projects</li> 
 <li>Background commit checks</li> 
 <li>Navigation to Spring Security matchers and request mappings</li> 
</ul> Visit our 
<a href="https://www.jetbrains.com/idea/whatsnew/">What's New page</a> to learn about all of the new features and improvements.
    