### PR TITLE
Upgrading IntelliJ from 2023.1.2 to 2023.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2023.1.2 to 2023.1.3
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup = com.chriscarini.jetbrains
 pluginName = 'Automatic Power Saver'
 # SemVer format -> https://semver.org
-pluginVersion = 3.0.2
+pluginVersion = 3.0.3
 
 ### I DO NOT MAKE USE OF SINCE/UNTIL IN THIS PLUGIN.
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
@@ -14,7 +14,7 @@ pluginVersion = 3.0.2
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2023.1.2,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2023.1.3,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 # Exclude `DEPRECATED_API_USAGES` as we use `FrameStateListener.onFrameDeactivated()` in
 # `FocusPowerSaveService.IdeFrameStatePowerSaveListener` (2022.3)
@@ -28,7 +28,7 @@ platformType = IC
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2023.1.2
+platformVersion = 2023.1.3
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html


### PR DESCRIPTION

# Upgrading IntelliJ from 2023.1.2 to 2023.1.3

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100661575/IntelliJ-IDEA-2023.1.3-231.9161.38-build-Release-Notes

# What's New?
IntelliJ IDEA 2023.1.3 is out with the following fixes: 
<ul> 
 <li>We fixed the issue that was causing the IDE to crash when using the navigation feature in Raycast. [<a href="https://youtrack.jetbrains.com/issue/IDEA-317346/">IDEA-317346</a>]</li> 
 <li>Navigation to implementations works as expected in decompiled classes. [<a href="https://youtrack.jetbrains.com/issue/IDEA-308933/">IDEA-308933</a>]</li> 
 <li>The issue with launching multi-module projects using the Quarkus run configuration has been resolved. [<a href="https://youtrack.jetbrains.com/issue/IDEA-317297/">IDEA-317297</a>]</li> 
 <li>The issue that caused the deletion of records from the list of local tasks has been fixed. [<a href="https://youtrack.jetbrains.com/issue/IDEA-274672/">IDEA-274672</a>]</li> 
 <li>We fixed the issues that were causing the main menu groups to malfunction and not process actions correctly on macOS. [<a href="https://youtrack.jetbrains.com/issue/IDEA-319117/">IDEA-319117</a>], [<a href="https://youtrack.jetbrains.com/issue/IDEA-318603/">IDEA-318603</a>] </li> 
 <li>Several issues that affected working in LightEdit mode have been fixed [<a href="https://youtrack.jetbrains.com/issue/IDEA-315639/">IDEA-315639</a>], [<a href="https://youtrack.jetbrains.com/issue/IDEA-315526/">IDEA-315526</a>], [<a href="https://youtrack.jetbrains.com/issue/IDEA-316537">IDEA-316537</a>].</li> 
 <li>Building JPS projects utilizing JDK 8 with both JDK and project files stored on WSL no longer fails. [<a href="https://youtrack.jetbrains.com/issue/IDEA-319240/">IDEA-319240</a>]</li> 
 <li>The IDE no longer erroneously reports autowiring errors in <em>@ConfigurationProperties</em> for fields set via <em>application.properties</em> when using Lombok in Spring Boot projects. [<a href="https://youtrack.jetbrains.com/issue/IDEA-319269/">IDEA-319269</a>]</li> 
 <li>Several issues appearing when setting active Spring profiles have been fixed. [<a href="https://youtrack.jetbrains.com/issue/IDEA-177780/Spring-autoconfiguration-no-actions-to-set-the-active-profile-are-available-in-the-project-w-o-explicit-Spring-facet">IDEA-177780</a>], [<a href="https://youtrack.jetbrains.com/issue/IDEA-177783/Spring-autoconfiguration-if-Spring-facet-is-defined-but-w-o-explicit-filesets-active-profiles-setting-doesnt-work">IDEA-177783</a>], [<a href="https://youtrack.jetbrains.com/issue/IDEA-309671/Spring-without-facet-no-possibility-to-set-the-active-profile">IDEA-309671</a>], [<a href="https://youtrack.jetbrains.com/issue/IDEA-314635/Spring-Tool-WIndow-ChangeActiveSpringProfiles-action-is-available-for-the-xml-based-configurations-only">IDEA-314635</a>]</li> 
</ul> For more details, refer to this 
<a href="https://blog.jetbrains.com/idea/2023/06/intellij-idea-2023-1-3/">blog post</a>.
    