### PR TITLE
Upgrading IntelliJ from 2023.2.3 to 2023.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2023.2.3 to 2023.2.4
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup = com.chriscarini.jetbrains
 pluginName = 'Automatic Power Saver'
 # SemVer format -> https://semver.org
-pluginVersion = 3.1.3
+pluginVersion = 3.1.4
 
 ### I DO NOT MAKE USE OF SINCE/UNTIL IN THIS PLUGIN.
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
@@ -14,7 +14,7 @@ pluginVersion = 3.1.3
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2023.2.3,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2023.2.4,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 # Exclude `DEPRECATED_API_USAGES` as we use `FrameStateListener.onFrameDeactivated()` in
 # `FocusPowerSaveService.IdeFrameStatePowerSaveListener` (2022.3)
@@ -28,7 +28,7 @@ platformType = IC
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2023.2.3
+platformVersion = 2023.2.4
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html


### PR DESCRIPTION

# Upgrading IntelliJ from 2023.2.3 to 2023.2.4

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100661715/IntelliJ-IDEA-2023.2.4-232.10203.10-build-Release-Notes

# What's New?
IntelliJ IDEA 2023.2.4 is out with the following improvements: 
<ul> 
 <li>The IDE now properly recognizes Spring configuration files when importing projects from Bazel. [<a href="https://youtrack.jetbrains.com/issue/IDEA-324807/">IDEA-324807</a>]</li> 
 <li>The IDE no longer hangs when deploying a WAR artifact to a remote Tomcat server. [<a href="https://youtrack.jetbrains.com/issue/IDEA-326787/Tomcat-service-will-not-deploy-to-remote-server-TomcatRemoteModel-cannot-be-cast-to-TomcatLocalModel">IDEA-326787</a>]</li> 
 <li>The list of directories is again correctly rendered in the <em>Project</em> tool window. [<a href="https://youtrack.jetbrains.com/issue/IDEA-326394">IDEA-326394</a>]</li> 
 <li>Absolute directory paths in the <em>Commit</em> tool window no longer take up too much space as a result of redundantly replicating parent paths. [<a href="https://youtrack.jetbrains.com/issue/IDEA-326271/Commit-window-shows-full-path-irregularly">IDEA-326271</a>]</li> 
 <li>The IDE now properly recognizes configuration properties inherited from superclasses when working with Spring Boot projects. [<a href="https://youtrack.jetbrains.com/issue/IDEA-330037/Spring-Boot-Inherited-POJO-properties-are-not-resolved-in-ConfigurationProperties">IDEA-330037</a>] </li> 
</ul> For more details, please refer to this 
<a href="https://blog.jetbrains.com/idea/2023/10/intellij-idea-2023-2-4/">blog post</a>.
    